### PR TITLE
Sumbit rules: New 7 apps support

### DIFF
--- a/com.baidu.netdisk.json
+++ b/com.baidu.netdisk.json
@@ -1,0 +1,13 @@
+{
+	"package": "com.baidu.netdisk",
+	"recommended": true,
+	"authors": ["fython"],
+	"need_appops": false,
+	"observers": [{
+		"description": "saved_files",
+		"call_media_scan": true,
+		"add_to_downloads": true,
+		"source": "BaiduNetdisk",
+		"target": "Download/BaiduNetdisk"
+	}]
+}

--- a/com.eico.weico.json
+++ b/com.eico.weico.json
@@ -1,0 +1,12 @@
+{
+	"package": "com.eico.weico",
+	"recommended": true,
+	"authors": ["fython"],
+	"need_appops": false,
+	"observers": [{
+		"description": "saved_pictures",
+		"call_media_scan": true,
+		"source": "Weico/Weico",
+		"target": "Pictures/Weico"
+	}]
+}

--- a/com.fastaccess.github.json
+++ b/com.fastaccess.github.json
@@ -1,0 +1,13 @@
+{
+	"package": "com.fastaccess.github",
+	"recommended": true,
+	"authors": ["fython"],
+	"need_appops": false,
+	"observers": [{
+		"description": "saved_files",
+		"call_media_scan": true,
+		"add_to_downloads": true,
+		"source": "FastHub",
+		"target": "Download/FastHub"
+	}]
+}

--- a/com.jingdong.app.mall.json
+++ b/com.jingdong.app.mall.json
@@ -1,0 +1,13 @@
+{
+	"package": "com.jingdong.app.mall",
+	"recommended": true,
+	"authors": ["fython"],
+	"need_appops": false,
+	"feature_affected": false,
+	"observers": [{
+		"description": "saved_pictures",
+		"call_media_scan": true,
+		"source": "jd/userPhoto",
+		"target": "Pictures/JD"
+	}]
+}

--- a/dev.nick.app.screencast.json
+++ b/dev.nick.app.screencast.json
@@ -1,0 +1,12 @@
+{
+	"package": "dev.nick.app.screencast",
+	"recommended": true,
+	"authors": ["fython"],
+	"need_appops": false,
+	"observers": [{
+		"description": "saved_videos",
+		"call_media_scan": true,
+		"source": "ScreenRecorder",
+		"target": "Movies/ScreenRecorder"
+	}]
+}

--- a/jp.pxv.android.json
+++ b/jp.pxv.android.json
@@ -1,0 +1,12 @@
+{
+	"package": "jp.pxv.android",
+	"recommended": true,
+	"authors": ["fython"],
+	"need_appops": false,
+	"observers": [{
+		"description": "saved_pictures",
+		"call_media_scan": true,
+		"source": "pixiv",
+		"target": "Pictures/Pixiv"
+	}]
+}

--- a/net.oneplus.weather.json
+++ b/net.oneplus.weather.json
@@ -1,0 +1,13 @@
+{
+	"package": "net.oneplus.weather",
+	"recommended": true,
+	"authors": ["fython"],
+	"need_appops": false,
+	"feature_affected": false,
+	"observers": [{
+		"description": "saved_pictures",
+		"call_media_scan": true,
+		"source": "OPWeather",
+		"target": "Pictures/OPWeatherShare"
+	}]
+}


### PR DESCRIPTION
Add applications support:

- Weico (`com.eico.weico`)
- Pixiv (`jp.pxv.android`)
- Baidu Netdisk (`com.baidu.netdisk`)
- OnePlus Weather (`net.oneplus.weather`)
- FastHub (`com.fastaccess.github`)
- Jingdong Mall (`com.jingdong.app.mall`)
- Screen Recorder (`dev.nick.app.screencast`)