### PR TITLE
修改 wps 应用内显示 和 chebada 目标文件夹

### DIFF
--- a/cn.wps.moffice_eng.json
+++ b/cn.wps.moffice_eng.json
@@ -4,7 +4,7 @@
     "need_appops": false,
     "authors": ["Shane"],
     "observers": [{
-		"description": "saved_documents",
+		"description": "saved_files",
 		"source": "documents",
 		"target": "Documents/WPS"
     }]

--- a/com.chebada.json
+++ b/com.chebada.json
@@ -7,6 +7,6 @@
 		"description": "saved_pictures",
 		"call_media_scan": true,
 		"source": "Pictures",
-		"target": "Pictures/巴士管家"
+		"target": "Pictures/BUS"
     }]
 }


### PR DESCRIPTION
* cn.wps.moffice_eng 应用内显示改为“保存的文件”
* com.chebada 目标文件夹改为英文
  根据 #66 中@RikkaW 的意见
  